### PR TITLE
file-based access objects can be returned to client as file:// URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,8 @@ apply plugin: 'com.bmuschko.nexus'
 
 archivesBaseName = 'ga4gh-starter-kit-drs'
 group 'org.ga4gh'
-version '0.1.3'
+// version '0.1.3'
+version '2021-05-17-NIGHTLY'
 
 repositories {
     // Use jcenter for resolving dependencies.

--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,7 @@ apply plugin: 'com.bmuschko.nexus'
 
 archivesBaseName = 'ga4gh-starter-kit-drs'
 group 'org.ga4gh'
-// version '0.1.3'
-version '2021-05-17-NIGHTLY'
+version '0.1.4'
 
 repositories {
     // Use jcenter for resolving dependencies.

--- a/src/main/java/org/ga4gh/starterkit/drs/app/DrsStandaloneSpringConfig.java
+++ b/src/main/java/org/ga4gh/starterkit/drs/app/DrsStandaloneSpringConfig.java
@@ -2,6 +2,7 @@ package org.ga4gh.starterkit.drs.app;
 
 import org.apache.commons.cli.Options;
 import org.ga4gh.starterkit.common.config.ServerProps;
+import org.ga4gh.starterkit.drs.config.DrsServiceProps;
 import org.ga4gh.starterkit.drs.model.DrsServiceInfo;
 import org.ga4gh.starterkit.common.util.CliYamlConfigLoader;
 import org.ga4gh.starterkit.common.util.DeepObjectMerger;
@@ -90,5 +91,12 @@ public class DrsStandaloneSpringConfig implements WebMvcConfigurer {
         @Qualifier(DrsStandaloneConstants.FINAL_DRS_CONFIG_CONTAINER) DrsStandaloneYamlConfigContainer drsConfigContainer
     ) {
         return drsConfigContainer.getDrs().getServiceInfo();
+    }
+
+    @Bean
+    public DrsServiceProps getDrsServiceProps(
+        @Qualifier(DrsStandaloneConstants.FINAL_DRS_CONFIG_CONTAINER) DrsStandaloneYamlConfigContainer drsConfigContainer
+    ) {
+        return drsConfigContainer.getDrs().getDrsServiceProps();
     }
 }

--- a/src/main/java/org/ga4gh/starterkit/drs/app/DrsStandaloneYamlConfig.java
+++ b/src/main/java/org/ga4gh/starterkit/drs/app/DrsStandaloneYamlConfig.java
@@ -2,6 +2,7 @@ package org.ga4gh.starterkit.drs.app;
 
 import org.ga4gh.starterkit.common.config.DatabaseProps;
 import org.ga4gh.starterkit.common.config.ServerProps;
+import org.ga4gh.starterkit.drs.config.DrsServiceProps;
 import org.ga4gh.starterkit.drs.model.DrsServiceInfo;
 
 public class DrsStandaloneYamlConfig {
@@ -9,11 +10,13 @@ public class DrsStandaloneYamlConfig {
     private ServerProps serverProps;
     private DatabaseProps databaseProps;
     private DrsServiceInfo serviceInfo;
+    private DrsServiceProps drsServiceProps;
 
     public DrsStandaloneYamlConfig() {
         serverProps = new ServerProps();
         databaseProps = new DatabaseProps();
         serviceInfo = new DrsServiceInfo();
+        drsServiceProps = new DrsServiceProps();
     }
 
     public void setServerProps(ServerProps serverProps) {
@@ -38,6 +41,14 @@ public class DrsStandaloneYamlConfig {
 
     public DatabaseProps getDatabaseProps() {
         return databaseProps;
+    }
+
+    public void setDrsServiceProps(DrsServiceProps drsServiceProps) {
+        this.drsServiceProps = drsServiceProps;
+    }
+
+    public DrsServiceProps getDrsServiceProps() {
+        return drsServiceProps;
     }
     
 }

--- a/src/main/java/org/ga4gh/starterkit/drs/config/DrsServiceProps.java
+++ b/src/main/java/org/ga4gh/starterkit/drs/config/DrsServiceProps.java
@@ -1,0 +1,33 @@
+package org.ga4gh.starterkit.drs.config;
+
+public class DrsServiceProps {
+
+    private boolean serveFileURLForFileObjects;
+    private boolean serveStreamURLForFileObjects;
+
+    public DrsServiceProps() {
+        setAllDefaults();
+    }
+
+    public void setServeFileURLForFileObjects(boolean serveFileURLForFileObjects) {
+        this.serveFileURLForFileObjects = serveFileURLForFileObjects;
+    }
+
+    public boolean getServeFileURLForFileObjects() {
+        return serveFileURLForFileObjects;
+    }
+
+    public void setServeStreamURLForFileObjects(boolean serveStreamURLForFileObjects) {
+        this.serveStreamURLForFileObjects = serveStreamURLForFileObjects;
+    }
+
+    public boolean getServeStreamURLForFileObjects() {
+        return serveStreamURLForFileObjects;
+    }
+
+    private void setAllDefaults() {
+        serveFileURLForFileObjects = false;
+        serveStreamURLForFileObjects = true;
+    }
+    
+}


### PR DESCRIPTION
Configuration YAML allows deployer to determine whether local files should be streamed back to client via streaming endpoint, and/or if a file URL should be returned (if assumed the client has access to the same filesystem)
