### PR TITLE
Feature/54 GitHub release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,8 +134,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: test-tag-name
-          release_name: test-release-name
+          tag_name: test-tag-name 
+          release_name: test-release-name v${{ env.version }} 
           # tag_name: v${{ env.version }} #will be v0.2.2 for example
           # release_name: GA4GH Starter Kit - DRS v${{ env.version }}
           draft: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
     name: Create GitHub Release
     needs: Docker-Integration-Test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
+    # if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -134,7 +134,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: v${{ env.version }} #will be v0.2.2 for example
-          release_name: GA4GH Starter Kit - DRS v${{ env.version }}
+          tag_name: test-tag-name
+          release_name: test-release-name
+          # tag_name: v${{ env.version }} #will be v0.2.2 for example
+          # release_name: GA4GH Starter Kit - DRS v${{ env.version }}
           draft: false
           prerelease: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ env.version }} #will be v0.2.2 for example
           release_name: GA4GH Starter Kit - DRS v${{ env.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
     name: Create GitHub Release
     needs: Docker-Integration-Test
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
     name: Create GitHub Release
     needs: Docker-Integration-Test
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -134,9 +134,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: test-tag-name 
-          release_name: test-release-name v${{ env.version }} 
-          # tag_name: v${{ env.version }} #will be v0.2.2 for example
-          # release_name: GA4GH Starter Kit - DRS v${{ env.version }}
+          tag_name: v${{ env.version }} #will be v0.2.2 for example
+          release_name: GA4GH Starter Kit - DRS v${{ env.version }}
           draft: false
           prerelease: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
     name: Create GitHub Release
     needs: Docker-Integration-Test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
+    # if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,3 +113,28 @@ jobs:
         build-args: VERSION=${{ env.version }}
         cache-from: type=gha #GitHub Actions Cache Exporter
         cache-to: type=gha,mode=max
+
+  build:
+    name: Create GitHub Release
+    needs: Docker-Integration-Test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get and Set Version
+        run: |
+          source ci/set-docker-image-version.sh
+          echo "version=${DOCKER_IMG_VER}" >> $GITHUB_ENV
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: v${{ env.version }} #will be v0.2.2 for example
+          release_name: GA4GH Starter Kit - DRS v${{ env.version }}
+          draft: false
+          prerelease: true

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ configurations.all {
 
 archivesBaseName = 'ga4gh-starter-kit-drs'
 group 'org.ga4gh'
-version '0.2.2'
+version '0.2.3' // will be changed back to 0.2.2 after
 
 repositories {
     // Use jcenter for resolving dependencies.

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ configurations.all {
 
 archivesBaseName = 'ga4gh-starter-kit-drs'
 group 'org.ga4gh'
-version '0.2.3' // will be changed back to 0.2.2 after
+version '0.2.2'
 
 repositories {
     // Use jcenter for resolving dependencies.


### PR DESCRIPTION
Similar to the docker release (#60), it creates a GitHub release if pushed into main. The version number (used in tag name and build name) has been tested to ensure it works.

Note: There are a lot more options to modify when making a GitHub release through GitHub Actions if need be, more details can be found [here](https://github.com/actions/create-release).